### PR TITLE
stop backprop to the generator by detaching

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,8 @@ for epoch in range(num_epoch):
         noise = torch.rand(batchSize,100).view(-1,100,1,1,1)
         noise = to_variable(noise)
 
-        fake_videos = generator(noise)
+	# stop backprop to the generator by detaching fake_videos
+        fake_videos = generator(noise).detach()
         outputs = discriminator(fake_videos)
         
         fake_score = outputs # Needed for tracking?


### PR DESCRIPTION
update: Sorry, I found I was wrong. Without detaching the generator won't be updated either. It seems that detaching only helps reduce the computation.
——
GAN is trained in an adversarial manner. Without detaching we will update generator when we are trying to minimize GANLoss, but generator should only be updated when we are trying to maximize the loss.
  